### PR TITLE
escape XML when substituting variables into Beaker job XML

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/beakerbuilder/XMLEscapingVariableResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/beakerbuilder/XMLEscapingVariableResolver.java
@@ -1,0 +1,23 @@
+package org.jenkinsci.plugins.beakerbuilder;
+
+import hudson.util.VariableResolver;
+
+public class XMLEscapingVariableResolver implements VariableResolver<String> {
+
+    private final VariableResolver<String> inner;
+
+    public XMLEscapingVariableResolver(VariableResolver<String> inner) {
+        this.inner = inner;
+    }
+
+    public String resolve(String name) {
+        String value = inner.resolve(name);
+        return value
+            .replaceAll("&", "&amp;")
+            .replaceAll(">", "&gt;")
+            .replaceAll("<", "&lt;")
+            .replaceAll("\"", "&quot;")
+            .replaceAll("'", "&apos;");
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/beakerbuilder/StringJobSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/beakerbuilder/StringJobSourceTest.java
@@ -29,7 +29,7 @@ public class StringJobSourceTest {
     @Test
     public void expandBuildParams() throws IOException, ExecutionException, InterruptedException {
         FreeStyleProject project = j.createFreeStyleProject();
-        ParameterDefinition stringParDef = new StringParameterDefinition("TestStringParam", "My test string parameter",
+        ParameterDefinition stringParDef = new StringParameterDefinition("TestStringParam", "My test string parameter < >",
                 "String description");
         ParameterDefinition boolParDef = new BooleanParameterDefinition("TestBooleanParam", true, "Bool description");
         project.addProperty(new ParametersDefinitionProperty(stringParDef, boolParDef));   
@@ -45,7 +45,7 @@ public class StringJobSourceTest {
         String actualJob = br.readLine();
         br.close();
         assertEquals(
-                "<test>Build #1: My test job with string param of with value My test string parameter and boolean param with value true</test>",
+                "<test>Build #1: My test job with string param of with value My test string parameter &lt; &gt; and boolean param with value true</test>",
                 actualJob);
     }
     


### PR DESCRIPTION
In our Beaker CI we have a Jenkins job which submits a Beaker job like this:

```
...
    <whiteboard>
        beaker dogfood for Gerrit change ${GERRIT_CHANGE_NUMBER} patch ${GERRIT_PATCHSET_NUMBER}: ${GERRIT_CHANGE_SUBJECT}
    </whiteboard>
...
```

If we are testing a commit which has XML in the commit message, this will be interpolated directly into the job XML and can cause an XML syntax error (or other undesired behaviour).
